### PR TITLE
Fixes to work with UcxShuffleTransport.

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -366,7 +366,7 @@ object ShuffleMetadata extends Logging{
   }
 
   def buildBlockMeta(tables: Seq[TableMeta], maximumResponseSize: Long): ByteBuffer = {
-    val fbb = new FlatBufferBuilder(1024, bbFactory)
+    val fbb = getBuilder
     val tableOffsets = copyTables(fbb, tables)
     val tableMetasOffset = BlockMeta.createTableMetasVector(fbb, tableOffsets)
     val finIndex = BlockMeta.createBlockMeta(fbb, tableMetasOffset)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
@@ -120,6 +120,7 @@ class RapidsDiskStore(
     }
 
     override protected def releaseResources(): Unit = {
+      close()
       require(hostBuffer.isEmpty,
         "Releasing a disk buffer with non-empty host buffer")
       // Buffers that share paths must be cleaned up elsewhere

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.shuffle
 
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 import java.util.concurrent.LinkedBlockingQueue
 
 import scala.collection.mutable
@@ -27,7 +27,7 @@ import com.nvidia.spark.rapids._
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle.ucx._
-import org.apache.spark.shuffle.{RapidsMetaBlockId, RapidsMetaResponse, RapidsShuffleBlock, RapidsShuffleFetchFailedException, RapidsShuffleTimeoutException}
+import org.apache.spark.shuffle.{RapidsBlockId, RapidsMetaBlockId, RapidsMetaResponse, RapidsShuffleBlock, RapidsShuffleFetchFailedException, RapidsShuffleTimeoutException}
 import org.apache.spark.sql.rapids.{GpuShuffleEnv, ShuffleMetricsUpdater}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.{BlockManagerId, ShuffleBlockBatchId, ShuffleBlockId}
@@ -150,7 +150,7 @@ class RapidsShuffleIterator(
 
   // this continues to be mutated as we get responses from the transport
   // if non-empty, we need to fetch
-  var tablesToFetch = Seq[(RapidsShuffleFetchHandler, ShuffleBlockId, TableMeta)]()
+  var tablesToFetch = mutable.Map[String, mutable.ListBuffer[(RapidsShuffleFetchHandler, ShuffleBlockId, TableMeta)]]()
 
   def start(): Unit = {
     logInfo(s"Fetching ${blocksByAddress.size} blocks.")
@@ -269,7 +269,8 @@ class RapidsShuffleIterator(
         val request = try {
           val transportRequests =
             shuffleRequestsMapIndex.map { bId => {
-              val resultBuffer = new RapidsMetaResponse(ByteBuffer.allocateDirect(1024 * 1024))
+              val resultBuffer = new RapidsMetaResponse(
+                ByteBuffer.allocateDirect(1024 * 1024).order(ByteOrder.LITTLE_ENDIAN))
               (RapidsMetaBlockId(bId.id.name), resultBuffer, new OperationCallback {
                 override def onComplete(result: OperationResult): Unit = {
                   result.getStatus match {
@@ -280,12 +281,14 @@ class RapidsShuffleIterator(
 
                       // let the iterator know it should expect these
                       handler.start(numTables)
-
+                      tablesToFetch.getOrElseUpdate(handler.getExecutorId(),
+                        mutable.ListBuffer.empty)
+                      val tablesForExecutor = tablesToFetch(handler.getExecutorId())
                       (0 until numTables).foreach { t =>
-                        tablesToFetch = tablesToFetch :+
+                        tablesForExecutor.prepend(
                             ((handler,
                             ShuffleBlockId(bId.id.shuffleId, bId.id.mapId, bId.id.startReduceId),
-                            ShuffleMetadata.copyTableMetaToHeap(blockMeta.tableMetas(t))))
+                            ShuffleMetadata.copyTableMetaToHeap(blockMeta.tableMetas(t)))))
                       }
                     case _ =>
                       val err = if (result.getError != null) {
@@ -305,6 +308,7 @@ class RapidsShuffleIterator(
                 }
               })
             }}
+
 
           transport.fetchBlocksByBlockIds(
             blockManagerId.executorId,
@@ -336,31 +340,36 @@ class RapidsShuffleIterator(
       s"${requests.size} requests.")
   }
 
-  def doFetch(
-      sbId: ShuffleBlockId,
-      handler: RapidsShuffleFetchHandler,
-      tableMeta: TableMeta): Unit = {
-    val tableId = tableMeta.bufferMeta().id()
-    val resultBuffer = DeviceMemoryBuffer.allocate(tableMeta.bufferMeta().size())
-    val rapidsBlock = new RapidsShuffleBlock(
-      ShuffleBufferId(sbId, tableId), resultBuffer, tableMeta)
-    transport.fetchBlockByBlockId(
-      handler.getExecutorId(),
-      rapidsBlock.getBlockId,
-      rapidsBlock.getMemoryBlock, (result: OperationResult) => {
+  def doFetch(executorId: String,
+      sbIds: Seq[ShuffleBlockId],
+      handlers: Seq[RapidsShuffleFetchHandler],
+      tableMetas: Seq[TableMeta]): Unit = {
+
+    val blockIds = new Array[RapidsBlockId](sbIds.length)
+    val blocksMemory = new Array[MemoryBlock](sbIds.length)
+    val callbacks = new Array[OperationCallback](sbIds.length)
+
+    for (i <- sbIds.indices) {
+      val tableId = tableMetas(i).bufferMeta().id()
+      val resultBuffer = DeviceMemoryBuffer.allocate(tableMetas(i).bufferMeta().size())
+      val rapidsBlock = new RapidsShuffleBlock(
+        ShuffleBufferId(sbIds(i), tableId), resultBuffer, tableMetas(i))
+      blockIds(i) = rapidsBlock.getBlockId
+      blocksMemory(i) = rapidsBlock.getMemoryBlock
+      callbacks(i) = (result: OperationResult) => {
         result.getStatus match {
           case OperationStatus.SUCCESS =>
             val id: ShuffleReceivedBufferId = catalog.nextShuffleReceivedBufferId()
             logDebug(s"Adding buffer id ${id} to catalog")
             //if (buffer != null) {
-              // add the buffer to the catalog so it is available for spill
-              inflightBytes -= resultBuffer.getLength
-              if (inflightBytes < 0) {
-                throw new IllegalStateException(s"inflightBytes became negative? ${inflightBytes}")
-              }
-              devStorage.addBuffer(
-                id, resultBuffer, tableMeta, SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY)
-              handler.batchReceived(id)
+            // add the buffer to the catalog so it is available for spill
+            inflightBytes -= resultBuffer.getLength
+            if (inflightBytes < 0) {
+              throw new IllegalStateException(s"inflightBytes became negative? ${inflightBytes}")
+            }
+            devStorage.addBuffer(
+              id, resultBuffer, tableMetas(i), SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY)
+            handlers(i).batchReceived(id)
             //} else {
             //  // no device data, just tracking metadata
             //  // TODO: need to handle this case:
@@ -371,18 +380,23 @@ class RapidsShuffleIterator(
             val errMsg = if (result.getError != null) {
               result.getError.getMessage
             } else {
-              s"Error while fetching batch ${sbId}.${tableId} from UCX"
+              s"Error while fetching batch ${sbIds(i)}.${tableId} from UCX"
             }
 
             throw new RapidsShuffleFetchFailedException(
-              handler.getBlockManagerId,
-              sbId.shuffleId,
-              sbId.mapId,
+              handlers(i).getBlockManagerId,
+              sbIds(i).shuffleId,
+              sbIds(i).mapId,
               0,
-              sbId.reduceId,
+              sbIds(i).reduceId,
               errMsg)
         }
-      })
+      }
+    }
+
+    transport.fetchBlocksByBlockIds(
+      executorId,
+      blockIds, blocksMemory, callbacks)
   }
 
   private[this] def receiveBufferCleaner(): Unit = {
@@ -459,22 +473,32 @@ class RapidsShuffleIterator(
 
     taskContext.foreach(GpuSemaphore.acquireIfNecessary)
 
-    // send fetch block
-    if (!tablesToFetch.isEmpty) {
-      // ask for what we have for now
-      if (inflightBytes < fetchUpToBytes) {
-        val tablesToFetchIter = tablesToFetch.iterator
-        var doRemove = 0
-        while (tablesToFetchIter.hasNext && inflightBytes < fetchUpToBytes) {
-          val (handler, blockId, tableMeta) = tablesToFetchIter.next()
+    // send fetch blocks
+    if (tablesToFetch.nonEmpty) {
+      while (tablesToFetch.nonEmpty && inflightBytes < fetchUpToBytes) {
+        val (executorId, tables) = tablesToFetch.head
+
+        var sbIds = mutable.ArrayBuffer.empty[ShuffleBlockId]
+        var handlers = mutable.ArrayBuffer.empty[RapidsShuffleFetchHandler]
+        var tableMetas = mutable.ArrayBuffer.empty[TableMeta]
+
+        while (tables.nonEmpty && (inflightBytes < fetchUpToBytes)) {
+          val (handler, sbId, tableMeta) = tables.remove(0)
           inflightBytes += tableMeta.bufferMeta().size()
-          doFetch(blockId, handler, tableMeta)
-          doRemove = doRemove + 1
+          sbIds += sbId
+          handlers += handler
+          tableMetas += tableMeta
         }
-        // all is single threaded, so this is OK for now
-        tablesToFetch = tablesToFetch.drop(doRemove)
-        transport.progress() // send some block requests
+
+        if (tables.nonEmpty) {
+          tablesToFetch(executorId) = tables
+        } else {
+          tablesToFetch.remove(executorId)
+        }
+
+        doFetch(executorId, sbIds, handlers, tableMetas)
       }
+      transport.progress() // send some block requests
     }
 
     val blockedStart = System.currentTimeMillis()

--- a/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleBlock.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleBlock.scala
@@ -3,15 +3,15 @@ package org.apache.spark.shuffle
 import java.nio.ByteBuffer
 
 import ai.rapids.cudf.MemoryBuffer
+import com.nvidia.spark.rapids.{RapidsBufferId, ShuffleBufferId, ShuffleMetadata}
 import com.nvidia.spark.rapids.format.TableMeta
-import com.nvidia.spark.rapids.{MetaUtils, RapidsBufferId, ShuffleBufferId, ShuffleMetadata}
 import org.openucx.jucx.UcxUtils
 
 import org.apache.spark.shuffle.ucx.{Block, BlockId, MemoryBlock}
-import org.apache.spark.storage.{ShuffleBlockBatchId, ShuffleBlockId}
+import org.apache.spark.storage.ShuffleBlockBatchId
 
 case class RapidsBlockId(bufferId: RapidsBufferId) extends BlockId
-case class RapidsMetaBlockId(shuffleBlockId: ShuffleBlockBatchId) extends BlockId
+case class RapidsMetaBlockId(shuffleBlockId: String) extends BlockId
 class RapidsMetaResponse(val bb: ByteBuffer)
     extends MemoryBlock(UcxUtils.getAddress(bb), bb.capacity())
 
@@ -19,13 +19,14 @@ class RapidsShuffleMetaBlock(
     shuffleBlockId: ShuffleBlockBatchId,
     tableMetas: Seq[TableMeta]) extends Block {
 
-  val res = ShuffleMetadata.buildBlockMeta(tableMetas, 1024L * 1024L)
+  val rapidsMetaBlockId = RapidsMetaBlockId(shuffleBlockId.name)
+
+  private val res: ByteBuffer =
+    ShuffleMetadata.buildBlockMeta(tableMetas, 1024L * 1024L)
 
   override def getMemoryBlock: MemoryBlock = {
-    MemoryBlock(UcxUtils.getAddress(res), res.capacity())
+    MemoryBlock(UcxUtils.getAddress(res), res.remaining(), true)
   }
-
-  val rapidsMetaBlockId = RapidsMetaBlockId(shuffleBlockId)
 
   def getBlockId: RapidsMetaBlockId = rapidsMetaBlockId
 }
@@ -33,7 +34,7 @@ class RapidsShuffleMetaBlock(
 class RapidsShuffleBlock(bufferId: ShuffleBufferId,
     buffer: MemoryBuffer, meta: TableMeta) extends Block {
   override def getMemoryBlock: MemoryBlock = {
-    MemoryBlock(buffer.getAddress, buffer.getLength)
+    MemoryBlock(buffer.getAddress, buffer.getLength, false)
   }
 
   val rapidsBlockId = RapidsBlockId(bufferId)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -16,25 +16,29 @@
 
 package org.apache.spark.sql.rapids
 
+import scala.collection.mutable
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Success
+
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.format.TableMeta
-import com.nvidia.spark.rapids.shuffle.{RapidsShuffleRequestHandler, RapidsShuffleServer, RapidsShuffleTransport}
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
-import scala.collection.mutable
-
-import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv, TaskContext}
-
+import com.nvidia.spark.rapids.shuffle.RapidsShuffleTransport
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.buffer.ManagedBuffer
+import org.apache.spark.rpc.RpcEnv
+import org.apache.spark.{SecurityManager, ShuffleDependency, SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.shuffle._
 import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.shuffle.ucx.{ShuffleTransport, UcxShuffleTransport}
+import org.apache.spark.shuffle.ucx.rpc.{UcxDriverRpcEndpoint, UcxExecutorRpcEndpoint}
+import org.apache.spark.shuffle.ucx.rpc.UcxRpcMessages.{ExecutorAdded, IntroduceAllExecutors}
+import org.apache.spark.shuffle.ucx.utils.SerializableDirectBuffer
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage._
+import org.apache.spark.util.RpcUtils
 
 class GpuShuffleHandle[K, V](
     val wrapped: ShuffleHandle,
@@ -170,6 +174,11 @@ class RapidsCachingWriter[K, V](
     val nvtxRange = new NvtxRange("RapidsCachingWriter.close", NvtxColor.CYAN)
     try {
       if (!success) {
+        cleanStorage()
+        None
+      } else {
+        // upon seeing this port, the other side will try to connect to the port
+        // in order to establish an UCX endpoint (on demand), if the topology has "rapids" in it.
         blocksWritten.foreach { bId =>
           val bufferIds: Array[ShuffleBufferId] = catalog.blockIdToBuffersIds(bId)
           bufferIds.foreach { bId =>
@@ -191,11 +200,6 @@ class RapidsCachingWriter[K, V](
           val rapidsMeta = new RapidsShuffleMetaBlock(sbId, metas)
           transport.register(rapidsMeta.getBlockId, rapidsMeta)
         }
-        cleanStorage()
-        None
-      } else {
-        // upon seeing this port, the other side will try to connect to the port
-        // in order to establish an UCX endpoint (on demand), if the topology has "rapids" in it.
         val shuffleServerId = if (transport != null) {
           val originalShuffleServerId = blockManager.blockManagerId
           BlockManagerId(
@@ -268,17 +272,53 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
     if (rapidsConf.shuffleTransportEnabled && !isDriver) {
       val transport =
         RapidsShuffleTransport.makeTransport(blockManager.shuffleServerId, rapidsConf)
-      transport.init()
+      initUcxTransport(transport.asInstanceOf[UcxShuffleTransport])
       Some(transport)
     } else {
       None
     }
   }
 
-  override def registerShuffle[K, V, C](
-      shuffleId: Int,
-      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+  @volatile private var initialized: Boolean = false
+  private val driverEndpointName = "ucx-shuffle-driver"
+
+  // TODO: initialize through IO plugin at the process start
+  private def initDriverRpc(): Unit = {
+    val rpcEnv = SparkEnv.get.rpcEnv
+    val driverEndpoint = new UcxDriverRpcEndpoint(rpcEnv)
+    rpcEnv.setupEndpoint(driverEndpointName, driverEndpoint)
+  }
+
+  private def initUcxTransport(ucxTransport: UcxShuffleTransport): Unit = this.synchronized {
+    if (!initialized) {
+      val blockManager = SparkEnv.get.blockManager.blockManagerId
+      val rpcEnv = RpcEnv.create("ucx-rpc-env", blockManager.host, blockManager.host,
+        blockManager.port, conf, new SecurityManager(conf), 1, clientMode = false)
+      logDebug("Initializing ucx transport")
+      val address = ucxTransport.init()
+      val executorEndpoint = new UcxExecutorRpcEndpoint(rpcEnv, ucxTransport)
+      val endpoint = rpcEnv.setupEndpoint(
+        s"ucx-shuffle-executor-${blockManager.executorId}",
+        executorEndpoint)
+
+      val driverEndpoint = RpcUtils.makeDriverRef(driverEndpointName, conf, rpcEnv)
+      driverEndpoint.ask[IntroduceAllExecutors](ExecutorAdded(blockManager.executorId,
+        endpoint, new SerializableDirectBuffer(address)))
+        .andThen {
+          case Success(msg) =>
+            logInfo(s"Receive reply $msg")
+            executorEndpoint.receive(msg)
+        }
+      initialized = true
+    }
+  }
+
+
+  override def registerShuffle[K, V, C](shuffleId: Int,
+                                        dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+
     // Always register with the wrapped handler so we can write to it ourselves if needed
+    initDriverRpc()
     val orig = wrapped.registerShuffle(shuffleId, dependency)
     if (!shouldFallThroughOnEverything && dependency.isInstanceOf[GpuShuffleDependency[K, V, C]]) {
       val handle = new GpuShuffleHandle(orig,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -273,6 +273,7 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
       val transport =
         RapidsShuffleTransport.makeTransport(blockManager.shuffleServerId, rapidsConf)
       initUcxTransport(transport.asInstanceOf[UcxShuffleTransport])
+      RapidsBufferCatalog.setTransport(transport)
       Some(transport)
     } else {
       None


### PR DESCRIPTION
1. Added `initTransport` and `initDriver` methods to establish RPC and exchange worker addresses. Probably need to extend UcxShuffleManager, to not copy these methods.
2. `RapidsMetaBlockId` should take a string to have the same hash. `ShuffleBatchBlockId` is a class.
3. Correctly construct UcxShuffeTransport class
4. Other minor fixes.

With this seems like it's working.